### PR TITLE
First try at a cosi-implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@
 /cpp/util/sync_task_test
 /cpp/util/task_test
 /cpp/util/thread_pool_test
+/cpp/third_party/cosi/stamp_request_test
 /depcomp
 /install-sh
 /java/build

--- a/Makefile.am
+++ b/Makefile.am
@@ -727,6 +727,27 @@ cpp_util_task_test_LDADD = \
 cpp_util_task_test_SOURCES = \
 	cpp/util/task_test.cc
 
+cpp_third_party_cosi_stamp_request_test_LDADD = \
+	cpp/libcore.a \
+	cpp/libtest.a \
+	$(json_c_LIBS) \
+	$(libevent_LIBS) \
+	$(leveldb_LIBS) \
+	-lprotobuf -lsqlite3
+
+cpp_third_party_cosi_stamp_request_test_SOURCES = \
+	cpp/third_party/cosi/stamp_request_test.cc \
+	cpp/third_party/cosi/stamp_request.cc \
+	cpp/client/async_log_client.cc \
+	cpp/fetcher/remote_peer.cc \
+	cpp/log/test_signer.cc \
+	cpp/proto/serializer.cc \
+	cpp/util/json_wrapper.cc \
+	cpp/util/libevent_wrapper.cc \
+	cpp/util/periodic_closure.cc \
+	cpp/util/protobuf_util.cc \
+	cpp/util/util.cc
+
 cpp_util_thread_pool_test_LDADD = \
 	cpp/libcore.a \
 	cpp/libtest.a \

--- a/Makefile.am
+++ b/Makefile.am
@@ -734,7 +734,6 @@ cpp_third_party_cosi_stamp_request_test_LDADD = \
 	$(libevent_LIBS) \
 	$(leveldb_LIBS) \
 	-lprotobuf -lsqlite3
-
 cpp_third_party_cosi_stamp_request_test_SOURCES = \
 	cpp/third_party/cosi/stamp_request_test.cc \
 	cpp/third_party/cosi/stamp_request.cc \

--- a/Makefile.am
+++ b/Makefile.am
@@ -97,7 +97,8 @@ TESTS = \
 	cpp/util/libevent_wrapper_test \
 	cpp/util/masterelection_test \
 	cpp/util/sync_task_test \
-	cpp/util/task_test
+	cpp/util/task_test \
+	cpp/third_party/cosi/stamp_request_test
 
 all-local:
 	$(MAKE) -C python
@@ -163,6 +164,7 @@ cpp_libcore_a_SOURCES = \
 	cpp/net/connection_pool.cc \
 	cpp/net/url.cc \
 	cpp/net/url_fetcher.cc \
+	cpp/third_party/cosi/stamp_request.cc \
 	cpp/third_party/curl/hostcheck.c \
 	cpp/third_party/isec_partners/openssl_hostname_validation.c \
 	cpp/util/etcd.cc \

--- a/cpp/log/tree_signer-inl.h
+++ b/cpp/log/tree_signer-inl.h
@@ -16,7 +16,7 @@
 #include "proto/serializer.h"
 #include "util/status.h"
 #include "util/util.h"
-#include "third_party/cosi/stam_request.h"
+#include "third_party/cosi/stamp_request.h"
 
 
 namespace cert_trans {

--- a/cpp/log/tree_signer-inl.h
+++ b/cpp/log/tree_signer-inl.h
@@ -323,6 +323,7 @@ void TreeSigner<Logged>::TimestampAndSign(uint64_t min_timestamp,
 
   // Cosi-extension: ask for a collective signature on our STH
   sth->set_cosi_signature(Cosi::SignTreeHead(sth));
+  VLOG(1) << "Signing cosi_signature done:" << sth->cosi_signature() << " - " << sth->sha256_root_hash();
 }
 
 

--- a/cpp/log/tree_signer-inl.h
+++ b/cpp/log/tree_signer-inl.h
@@ -16,6 +16,7 @@
 #include "proto/serializer.h"
 #include "util/status.h"
 #include "util/util.h"
+#include "third_party/cosi/stam_request.h"
 
 
 namespace cert_trans {
@@ -319,6 +320,9 @@ void TreeSigner<Logged>::TimestampAndSign(uint64_t min_timestamp,
   if (ret != LogSigner::OK)
     // Make this one a hard fail. There is really no excuse for it.
     abort();
+
+  // Cosi-extension: ask for a collective signature on our STH
+  sth->set_cosi_signature(Cosi::SignTreeHead(sth));
 }
 
 

--- a/cpp/log/tree_signer-inl.h
+++ b/cpp/log/tree_signer-inl.h
@@ -323,7 +323,7 @@ void TreeSigner<Logged>::TimestampAndSign(uint64_t min_timestamp,
 
   // Cosi-extension: ask for a collective signature on our STH
   sth->set_cosi_signature(Cosi::SignTreeHead(sth));
-  VLOG(1) << "Signing cosi_signature done:" << sth->cosi_signature() << " - " << sth->sha256_root_hash();
+  VLOG(1) << "Signing cosi_signature done:" << sth->cosi_signature();
 }
 
 

--- a/cpp/server/handler.cc
+++ b/cpp/server/handler.cc
@@ -432,6 +432,7 @@ void HttpHandler::GetSTH(evhttp_request* req) const {
   json_reply.Add("timestamp", sth.timestamp());
   json_reply.AddBase64("sha256_root_hash", sth.sha256_root_hash());
   json_reply.Add("tree_head_signature", sth.signature());
+  json_reply.Add("cosi_signature", sth.cosi_signature());
 
   VLOG(2) << "GetSTH:\n" << json_reply.DebugString();
 

--- a/cpp/third_party/cosi/stamp_request.cc
+++ b/cpp/third_party/cosi/stamp_request.cc
@@ -28,15 +28,15 @@ namespace Cosi{
   string requestSignature(const string host, int port, const string msg);
 
   #define MAXRECV 1024
-  #define HOST "localhost"
+  #define HOST "127.0.0.1"
   #define PORT 2011
   #define HOST_P "78.46.227.60"
-  #define PORT_P 2001
+  #define PORT_P 2011
 
   string SignTreeHead(ct::SignedTreeHead* sth){
     cout << "Asking to sign tree head\n";
-    string host = HOST_P;
-    int port = PORT_P;
+    string host = HOST;
+    int port = PORT;
     return requestSignature(host, port, sth->sha256_root_hash());
   }
 
@@ -49,8 +49,8 @@ namespace Cosi{
     }
 
     cout << "Binary message " << BytesToHex((const unsigned char*)msg2.c_str(), msg2.length()) << "\n";
-    //string msg = util::ToBase64(msg2);
-    string msg = "test";
+    string msg = util::ToBase64(msg2);
+    //string msg = "test";
     cout << "Sending json with message2: " << msg << "\n";
     string request = json_request + msg + json_request_end;
     cout << "Request is: " << request << "\n";
@@ -95,7 +95,7 @@ namespace Cosi{
 
     if ( errno == EAFNOSUPPORT ) return -1;
 
-    cout << "Going to connect\n";
+    cout << "Going to connect to " << host << "\n";
     status = ::connect ( m_sock, ( sockaddr * ) &m_addr, sizeof ( m_addr ) );
     cout << "Connected\n";
 

--- a/cpp/third_party/cosi/stamp_request.cc
+++ b/cpp/third_party/cosi/stamp_request.cc
@@ -31,12 +31,12 @@ namespace Cosi{
   #define HOST "127.0.0.1"
   #define PORT 2011
   #define HOST_P "78.46.227.60"
-  #define PORT_P 2011
+  #define PORT_P 2001
 
   string SignTreeHead(ct::SignedTreeHead* sth){
-    cout << "Asking to sign tree head\n";
-    string host = HOST;
-    int port = PORT;
+    VLOG(2) << "Asking to sign tree head\n";
+    string host = HOST_P;
+    int port = PORT_P;
     return requestSignature(host, port, sth->sha256_root_hash());
   }
 
@@ -48,28 +48,26 @@ namespace Cosi{
       return NULL;
     }
 
-    cout << "Binary message " << BytesToHex((const unsigned char*)msg2.c_str(), msg2.length()) << "\n";
     string msg = util::ToBase64(msg2);
-    //string msg = "test";
-    cout << "Sending json with message2: " << msg << "\n";
+    VLOG(2) << "Sending json with message2: " << msg << "\n";
     string request = json_request + msg + json_request_end;
-    cout << "Request is: " << request << "\n";
+    VLOG(3) << "Request is: " << request << "\n";
     if ( writeString(m_sock, request) < 0 ){
-      cout << "Sending error\n";
+      VLOG(1) << "Sending error\n";
       return NULL;
     }
 
-    cout << "Waiting for string\n";
+    VLOG(3) << "Waiting for string\n";
 
     string signature = readString(m_sock);
-    cout << "Got signature " << signature << "\n";
+    VLOG(2) << "Got signature " << signature << "\n";
 
-    cout << "Sending stop\n";
+    VLOG(3) << "Sending stop\n";
     if ( writeString(m_sock, json_close) < 0 ){
       return NULL;
     }
 
-    cout << "Returning signature " << signature << "\n";
+    VLOG(2) << "Returning signature " << signature << "\n";
     return signature;
   }
 
@@ -95,9 +93,9 @@ namespace Cosi{
 
     if ( errno == EAFNOSUPPORT ) return -1;
 
-    cout << "Going to connect to " << host << "\n";
+    VLOG(2) << "Going to connect to " << host << "\n";
     status = ::connect ( m_sock, ( sockaddr * ) &m_addr, sizeof ( m_addr ) );
-    cout << "Connected\n";
+    VLOG(2) << "Connected\n";
 
     if ( status < 0 ){
       return -1;
@@ -110,7 +108,7 @@ namespace Cosi{
 
     if ( status == -1 ){
       int err=errno;
-      cout << strerror(err);
+      VLOG(2) << strerror(err);
       return -1;
     }
     return status;
@@ -125,27 +123,5 @@ namespace Cosi{
       return NULL;
     }
     return buf;
-  }
-
-  char *HexToBytes(const string& hex) {
-    char *bytes = (char*) malloc(hex.size());
-
-    for (unsigned int i = 0; i < hex.length(); i += 2) {
-      string byteString = hex.substr(i, 2);
-      char byte = (char) strtol(byteString.c_str(), NULL, 16);
-      bytes[i / 2] = byte;
-    }
-
-    return bytes;
-  }
-
-  char *BytesToHex(const unsigned char *bytes, int len) {
-    char *hex = (char*) malloc(len * 2) + 1;
-
-    for (unsigned int i = 0; i < len; i++) {
-      sprintf(&hex[i * 2], "%02x", bytes[i]);
-    }
-    hex[2 * len] = 0;
-    return hex;
   }
 }

--- a/cpp/third_party/cosi/stamp_request.cc
+++ b/cpp/third_party/cosi/stamp_request.cc
@@ -23,6 +23,7 @@ namespace Cosi{
   int writeString(int m_sock, string msg);
   char *readString(int m_sock);
   char *HexToBytes(const string& hex);
+  char *BytesToHex(const string& bytes);
   string requestSignature(const string host, int port, const string msg);
 
   #define MAXRECV 1024
@@ -39,22 +40,25 @@ namespace Cosi{
 
   // Requests a signature from the stamp-server at host:port - returns NULL if
   // not successful or the string with the JSON-representation of the signature
-  std::string requestSignature(const std::string host, int port, const std::string msg ){
+  std::string requestSignature(const std::string host, int port, const std::string msg2 ){
     int m_sock = connectTo(host, port);
     if ( m_sock < 0 ){
       return NULL;
     }
 
-    cout << "Sending json\n";
+    char *msg = BytesToHex(msg2);
+    cout << "Sending json with message2: " << msg << "\n";
     string request = json_request + msg + json_request_end;
     if ( writeString(m_sock, request) < 0 ){
       cout << "Sending error\n";
       return NULL;
     }
+    free(msg);
 
     cout << "Waiting for string\n";
 
-    string signature = readString(m_sock);;
+    string signature = readString(m_sock);
+    cout << "Got signature " << signature << "\n";
 
     cout << "Sending stop\n";
     if ( writeString(m_sock, json_close) < 0 ){
@@ -126,5 +130,15 @@ namespace Cosi{
     }
 
     return bytes;
+  }
+
+  char *BytesToHex(const string& bytes) {
+    char *hex = (char*) malloc(bytes.size() * 2) + 1;
+
+    for (unsigned int i = 0; i < bytes.size(); i++) {
+      sprintf(&hex[i * 2], "%02X", bytes[i]);
+    }
+    hex[2 * bytes.size()] = 0;
+    return hex;
   }
 }

--- a/cpp/third_party/cosi/stamp_request.cc
+++ b/cpp/third_party/cosi/stamp_request.cc
@@ -34,27 +34,34 @@ namespace Cosi{
     Serializer::SerializeSTHSignatureInput(*sth, &serialized_sth);
     if (res != Serializer::OK) return "error";
 
-    return requestSignature("localhost", 2021, serialized_sth);
+    return requestSignature("78.46.227.60", 2001, serialized_sth);
   }
 
   // Requests a signature from the stamp-server at host:port - returns NULL if
   // not successful or the string with the JSON-representation of the signature
-  string requestSignature(const string host, int port, const string msg ){
+  std::string requestSignature(const std::string host, int port, const std::string msg ){
     int m_sock = connectTo(host, port);
     if ( m_sock < 0 ){
       return NULL;
     }
 
+    cout << "Sending json\n";
     string request = json_request + msg + json_request_end;
     if ( writeString(m_sock, request) < 0 ){
+      cout << "Sending error\n";
       return NULL;
     }
+
+    cout << "Waiting for string\n";
 
     string signature = readString(m_sock);;
 
+    cout << "Sending stop\n";
     if ( writeString(m_sock, json_close) < 0 ){
       return NULL;
     }
+
+    cout << "Returning signature " << signature << "\n";
     return signature;
   }
 

--- a/cpp/third_party/cosi/stamp_request.cpp
+++ b/cpp/third_party/cosi/stamp_request.cpp
@@ -38,23 +38,17 @@ namespace Cosi{
   string requestSignature(char *host, int port, string msg ){
     int m_sock = connectTo(host, port);
     if ( m_sock < 0 ){
-      cout << "Connection error\n";
       return NULL;
     }
 
     string request = json_request + msg + json_request_end;
-    cout << "Sending message: " + request + "\n";
     if ( writeString(m_sock, request) < 0 ){
-      cout << "Error while writing signing request\n";
       return NULL;
     }
 
     string signature = readString(m_sock);;
-    cout << "Got string: " << signature;
 
-    cout << "Sending message: " + json_close;
     if ( writeString(m_sock, json_close) < 0 ){
-      cout << "Error while asking to close\n";
       return NULL;
     }
     return signature;
@@ -65,14 +59,12 @@ namespace Cosi{
     int m_sock = socket ( AF_INET, SOCK_STREAM, 0 );
 
     if ( m_sock == -1 ){
-      cout << "could't create socket\n";
       return -1;
     }
 
     // TIME_WAIT - argh
     int on = 1;
     if ( setsockopt ( m_sock, SOL_SOCKET, SO_REUSEADDR, ( const char* ) &on, sizeof ( on ) ) == -1 ){
-      cout << "could't connect\n";
       return -1;
     }
 
@@ -86,7 +78,6 @@ namespace Cosi{
     status = ::connect ( m_sock, ( sockaddr * ) &m_addr, sizeof ( m_addr ) );
 
     if ( status < 0 ){
-      cout << "could't connect\n";
       return -1;
     }
     return m_sock;
@@ -108,7 +99,6 @@ namespace Cosi{
     memset ( buf, 0, MAXRECV + 1 );
     int status = ::recv ( m_sock, buf, MAXRECV, 0 );
     if ( status == -1 ){
-      cout << "status == -1   errno == " << errno << "  in Socket::recv\n";
       free(buf);
       return NULL;
     }
@@ -123,9 +113,6 @@ namespace Cosi{
       char byte = (char) strtol(byteString.c_str(), NULL, 16);
       bytes[i / 2] = byte;
     }
-
-    cout << hex.length() / 2;
-    cout << " bytes converted\n";
 
     return bytes;
   }

--- a/cpp/third_party/cosi/stamp_request.cpp
+++ b/cpp/third_party/cosi/stamp_request.cpp
@@ -1,0 +1,132 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <string>
+#include <arpa/inet.h>
+
+namespace Cosi{
+  using std;
+
+  string json_request = "{\"ReqNo\":0,\"Type\":1,\"Srep\":null,\"Sreq\":{\"Val\":\"";
+  string json_request_end = "\"}}";
+  string json_close = "{\"ReqNo\":1,\"Type\":3}\n";
+
+  int connectTo(char *host, int port);
+  int writeString(int m_sock, string msg);
+  char *readString(int m_sock);
+  char *HexToBytes(const string& hex);
+  string requestSignature(char *host, int port);
+
+  #define MAXRECV 1024
+
+  string SignTreeHead(SignedTreeHead* sth){
+    string serialized_sth;
+    Serializer::SerializeResult res =
+    Serializer::SerializeSTHSignatureInput(*sth, &serialized_sth);
+    if (res != Serializer::OK) return GetSerializeError(res);
+
+    return requestSignature("localhost", 2021, serialized_sth);
+  }
+
+  // Requests a signature from the stamp-server at host:port - returns NULL if
+  // not successful or the string with the JSON-representation of the signature
+  string requestSignature(char *host, int port, string msg ){
+    int m_sock = connectTo(host, port);
+    if ( m_sock < 0 ){
+      cout << "Connection error\n";
+      return NULL;
+    }
+
+    string request = json_request + msg + json_request_end;
+    cout << "Sending message: " + request + "\n";
+    if ( writeString(m_sock, request) < 0 ){
+      cout << "Error while writing signing request\n";
+      return NULL;
+    }
+
+    string signature = readString(m_sock);;
+    cout << "Got string: " << signature;
+
+    cout << "Sending message: " + json_close;
+    if ( writeString(m_sock, json_close) < 0 ){
+      cout << "Error while asking to close\n";
+      return NULL;
+    }
+    return signature;
+  }
+
+  int connectTo(char *host, int port){
+    sockaddr_in m_addr;
+    int m_sock = socket ( AF_INET, SOCK_STREAM, 0 );
+
+    if ( m_sock == -1 ){
+      cout << "could't create socket\n";
+      return -1;
+    }
+
+    // TIME_WAIT - argh
+    int on = 1;
+    if ( setsockopt ( m_sock, SOL_SOCKET, SO_REUSEADDR, ( const char* ) &on, sizeof ( on ) ) == -1 ){
+      cout << "could't connect\n";
+      return -1;
+    }
+
+    m_addr.sin_family = AF_INET;
+    m_addr.sin_port = htons ( port );
+
+    int status = inet_pton ( AF_INET, host, &m_addr.sin_addr );
+
+    if ( errno == EAFNOSUPPORT ) return -1;
+
+    status = ::connect ( m_sock, ( sockaddr * ) &m_addr, sizeof ( m_addr ) );
+
+    if ( status < 0 ){
+      cout << "could't connect\n";
+      return -1;
+    }
+    return m_sock;
+  }
+
+  int writeString(int m_sock, string msg){
+    int status = ::write ( m_sock, msg.c_str(), msg.length() );
+
+    if ( status == -1 ){
+      int err=errno;
+      cout << strerror(err);
+      return -1;
+    }
+    return status;
+  }
+
+  char *readString(int m_sock){
+    char *buf = (char*)malloc( MAXRECV + 1 );
+    memset ( buf, 0, MAXRECV + 1 );
+    int status = ::recv ( m_sock, buf, MAXRECV, 0 );
+    if ( status == -1 ){
+      cout << "status == -1   errno == " << errno << "  in Socket::recv\n";
+      free(buf);
+      return NULL;
+    }
+    return buf;
+  }
+
+  char *HexToBytes(const string& hex) {
+    char *bytes = (char*) malloc(hex.size());
+
+    for (unsigned int i = 0; i < hex.length(); i += 2) {
+      string byteString = hex.substr(i, 2);
+      char byte = (char) strtol(byteString.c_str(), NULL, 16);
+      bytes[i / 2] = byte;
+    }
+
+    cout << hex.length() / 2;
+    cout << " bytes converted\n";
+
+    return bytes;
+  }
+}

--- a/cpp/third_party/cosi/stamp_request.h
+++ b/cpp/third_party/cosi/stamp_request.h
@@ -1,5 +1,6 @@
-
+#include "proto/ct.pb.h"
 
 namespace Cosi{
-  string SignTreeHead(SignedTreeHead* sth);
+  std::string requestSignature(const std::string host, int port, const std::string msg);
+  std::string SignTreeHead(ct::SignedTreeHead* sth);
 }

--- a/cpp/third_party/cosi/stamp_request.h
+++ b/cpp/third_party/cosi/stamp_request.h
@@ -3,4 +3,5 @@
 namespace Cosi{
   std::string requestSignature(const std::string host, int port, const std::string msg);
   std::string SignTreeHead(ct::SignedTreeHead* sth);
+  char *BytesToHex(const unsigned char *bytes, int len);
 }

--- a/cpp/third_party/cosi/stamp_request.h
+++ b/cpp/third_party/cosi/stamp_request.h
@@ -1,0 +1,5 @@
+
+
+namespace Cosi{
+  string SignTreeHead(SignedTreeHead* sth);
+}

--- a/cpp/third_party/cosi/stamp_request_test.cc
+++ b/cpp/third_party/cosi/stamp_request_test.cc
@@ -13,9 +13,12 @@
 using namespace std;
 
 int main(){
+  const unsigned char bytes[5]={0x00, 0x40, 0x80, 0xc0, 0xff};
+  cout << "Conversion: " << Cosi::BytesToHex(bytes, 5) << "\n";
+
   string test;
   cout << "Requesting signature\n";
-  cout << Cosi::requestSignature("78.46.227.60", 2001, " 0 1 0 0 150FFFFFF56 0 0 0 0 0 0 0 0FFFFFF42FFFF1C14FFFFFFFFFF6FFF2427FF41FF64FFFF4CFFFFFF1B7852FF55" );
+  cout << Cosi::requestSignature("localhost", 2011, " 0 1 0 0 150FFFFFF56 0 0 0 0 0 0 0 0FFFFFF42FFFF1C14FFFFFFFFFF6FFF2427FF41FF64FFFF4CFFFFFF1B7852FF55" );
 
   ct::SignedTreeHead sth;
   sth.set_timestamp(1000);

--- a/cpp/third_party/cosi/stamp_request_test.cc
+++ b/cpp/third_party/cosi/stamp_request_test.cc
@@ -9,21 +9,35 @@
 #include <string.h>
 #include <arpa/inet.h>
 #include "stamp_request.h"
+#include "util/testing.h"
+#include "util/status_test_util.h"
+
+class StampRequestTest : public ::testing::Test {
+protected:
+  StampRequestTest(){
+  }
+
+  void SetUp() {
+  }
+};
 
 using namespace std;
 
-int main(){
-  const unsigned char bytes[5]={0x00, 0x40, 0x80, 0xc0, 0xff};
-  cout << "Conversion: " << Cosi::BytesToHex(bytes, 5) << "\n";
-
+TEST_F(StampRequestTest, SignSTH){
   string test;
-  cout << "Requesting signature\n";
-  cout << Cosi::requestSignature("localhost", 2011, " 0 1 0 0 150FFFFFF56 0 0 0 0 0 0 0 0FFFFFF42FFFF1C14FFFFFFFFFF6FFF2427FF41FF64FFFF4CFFFFFF1B7852FF55" );
+  VLOG(2) << "Requesting signature\n";
+  VLOG(2) << Cosi::requestSignature("localhost", 2011, " 0 1 0 0 150FFFFFF56 0 0 0 0 0 0 0 0FFFFFF42FFFF1C14FFFFFFFFFF6FFF2427FF41FF64FFFF4CFFFFFF1B7852FF55" );
 
   ct::SignedTreeHead sth;
   sth.set_timestamp(1000);
-  cout << "Asking STH to be signed\n";
-  cout << Cosi::SignTreeHead( &sth );
-  cout << "Signature received\n";
-  return 0;
+  VLOG(2) << "Asking STH to be signed\n";
+  string sth_signed = Cosi::SignTreeHead( &sth );
+  VLOG(2) << sth_signed;
+  ASSERT_NE(sth_signed, "");
+  VLOG(2) << "Signature received\n";
+}
+
+int main(int argc, char** argv) {
+  cert_trans::test::InitTesting(argv[0], &argc, &argv, true);
+  return RUN_ALL_TESTS();
 }

--- a/cpp/third_party/cosi/stamp_request_test.cc
+++ b/cpp/third_party/cosi/stamp_request_test.cc
@@ -1,0 +1,20 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <string.h>
+#include <arpa/inet.h>
+#include "stamp_request.h"
+
+using namespace std;
+
+int main(){
+  std::cout << "hello\n";
+  string test;
+  test = Cosi::requestSignature("localhost", 2021, "test" );
+  return -1;
+}

--- a/cpp/third_party/cosi/stamp_request_test.cc
+++ b/cpp/third_party/cosi/stamp_request_test.cc
@@ -13,8 +13,14 @@
 using namespace std;
 
 int main(){
-  std::cout << "hello\n";
   string test;
-  test = Cosi::requestSignature("localhost", 2021, "test" );
-  return -1;
+  cout << "Requesting signature\n";
+  cout << Cosi::requestSignature("78.46.227.60", 2001, "test" );
+
+  ct::SignedTreeHead sth;
+  sth.set_timestamp(1000);
+  cout << "Asking STH to be signed\n";
+  cout << Cosi::SignTreeHead( &sth );
+  cout << "Signature received\n";
+  return 0;
 }

--- a/cpp/third_party/cosi/stamp_request_test.cc
+++ b/cpp/third_party/cosi/stamp_request_test.cc
@@ -15,7 +15,7 @@ using namespace std;
 int main(){
   string test;
   cout << "Requesting signature\n";
-  cout << Cosi::requestSignature("78.46.227.60", 2001, "test" );
+  cout << Cosi::requestSignature("78.46.227.60", 2001, " 0 1 0 0 150FFFFFF56 0 0 0 0 0 0 0 0FFFFFF42FFFF1C14FFFFFFFFFF6FFF2427FF41FF64FFFF4CFFFFFF1B7852FF55" );
 
   ct::SignedTreeHead sth;
   sth.set_timestamp(1000);

--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -129,7 +129,6 @@ func (c *LogClient) fetchAndParse(uri string, res interface{}) error {
 	var body []byte
 	if resp != nil {
 		body, err = ioutil.ReadAll(resp.Body)
-		log.Printf("%+v\n", string(body))
 		resp.Body.Close()
 		if err != nil {
 			return err

--- a/go/client/logclient.go
+++ b/go/client/logclient.go
@@ -62,6 +62,7 @@ type getSTHResponse struct {
 	Timestamp         uint64 `json:"timestamp"`           // Time that the tree was created
 	SHA256RootHash    string `json:"sha256_root_hash"`    // Root hash of the tree
 	TreeHeadSignature string `json:"tree_head_signature"` // Log signature for this STH
+	CosiSignature     string `json:"cosi_signature"` 			// Signature of the cosi-nodes
 }
 
 // base64LeafEntry respresents a Base64 encoded leaf entry
@@ -128,6 +129,7 @@ func (c *LogClient) fetchAndParse(uri string, res interface{}) error {
 	var body []byte
 	if resp != nil {
 		body, err = ioutil.ReadAll(resp.Body)
+		log.Printf("%+v\n", string(body))
 		resp.Body.Close()
 		if err != nil {
 			return err
@@ -260,6 +262,7 @@ func (c *LogClient) GetSTH() (sth *ct.SignedTreeHead, err error) {
 	sth = &ct.SignedTreeHead{
 		TreeSize:  resp.TreeSize,
 		Timestamp: resp.Timestamp,
+		CosiSignature: resp.CosiSignature,
 	}
 
 	rawRootHash, err := base64.StdEncoding.DecodeString(resp.SHA256RootHash)

--- a/go/cosi/cosi.go
+++ b/go/cosi/cosi.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"os"
+	"strings"
+	"io/ioutil"
+
+	"github.com/dedis/cothority/app/conode/defs"
+	"github.com/dedis/cothority/lib/app"
+	"github.com/dedis/cothority/lib/cliutils"
+	dbg "github.com/dedis/cothority/lib/debug_lvl"
+	"github.com/dedis/cothority/lib/hashid"
+	"github.com/dedis/cothority/lib/proof"
+	"github.com/dedis/crypto/abstract"
+	"github.com/google/certificate-transparency/go/client"
+)
+
+var logUri = flag.String("log_uri", "http://ct.googleapis.com/aviator", "CT log base URI")
+var dump = flag.Bool("dump", false, "Dump request to uri")
+
+var public abstract.Point
+
+func main() {
+	ReadConf()
+	logClient := client.New(*logUri)
+	STH, err := logClient.GetSTH()
+	if err != nil {
+		dbg.Fatal("Couldn't get STH:", err)
+	}
+	dbg.Printf("STH is %+v", STH)
+
+	if *dump {
+		ioutil.WriteFile("test_sth_cosi.json", []byte(STH.CosiSignature), 0660)
+		ioutil.WriteFile("test_sth_sha256.json",
+			[]byte(STH.SHA256RootHash.Base64String()), 0660)
+	} else {
+		sig, err := JSONtoSignature(STH.CosiSignature)
+		dbg.Printf("signature is %+v - error: &s\n", sig, err)
+		//VerifySignature(c.Args().First(), c.String("sig"))
+	}
+}
+
+func SetSuite(suiteStr string) {
+	suite = app.GetSuite(suiteStr)
+}
+
+func ReadConf() {
+	flag.Parse()
+
+	conf = new(app.ConfigConode)
+	err := app.ReadTomlConfig(conf, "config.toml")
+	if err != nil {
+		dbg.Fatal("Couldn't load config-fiel")
+	}
+	SetSuite(conf.Suite)
+	public, _ = cliutils.ReadPub64(suite, strings.NewReader(conf.AggPubKey))
+}
+
+// Our crypto-suite used in the program
+var suite abstract.Suite
+
+// the configuration file of the cothority tree used
+var conf *app.ConfigConode
+
+// Verifies that the 'message' is included in the signature and that it
+// is correct.
+// Message is your own hash, and reply contains the inclusion proof + signature
+// on the aggregated message
+func verifySignature(message hashid.HashId, reply *defs.StampReply) bool {
+	// First check if the challenge is ok
+	if err := verifyChallenge(suite, reply); err != nil {
+		dbg.Lvl1("Challenge-check : FAILED (", err, ")")
+		return false
+	}
+	dbg.Lvl1("Challenge-check : OK")
+	// Then check if the signature is ok
+	sig := defs.BasicSignature{
+		Chall: reply.SigBroad.C,
+		Resp:  reply.SigBroad.R0_hat,
+	}
+	public, _ := cliutils.ReadPub64(suite, strings.NewReader(conf.AggPubKey))
+	// Incorporate the timestamp in the message since the verification process
+	// is done by reconstructing the challenge
+	var b bytes.Buffer
+	if err := binary.Write(&b, binary.LittleEndian, reply.Timestamp); err != nil {
+		dbg.Lvl1("Error marshaling the timestamp for signature verification")
+	}
+	msg := append(b.Bytes(), []byte(reply.MerkleRoot)...)
+	if err := SchnorrVerify(suite, msg, public, sig); err != nil {
+		dbg.Lvl1("Signature-check : FAILED (", err, ")")
+		return false
+	}
+	dbg.Lvl1("Signature-check : OK")
+
+	// finally check the proof
+	if !proof.CheckProof(suite.Hash, reply.MerkleRoot, hashid.HashId(message), reply.Prf) {
+		dbg.Lvl1("Inclusion-check : FAILED")
+		return false
+	}
+	dbg.Lvl1("Inclusion-check : OK")
+	return true
+}
+
+// verifyChallenge will recontstruct the challenge in order to see if any of the
+// components of the challenge has been spoofed or not. It may be a different
+// timestamp .
+func verifyChallenge(suite abstract.Suite, reply *defs.StampReply) error {
+
+	// marshal the V
+	pbuf, err := reply.SigBroad.V0_hat.MarshalBinary()
+	if err != nil {
+		return err
+	}
+	c := suite.Cipher(pbuf)
+	// concat timestamp and merkle root
+	var b bytes.Buffer
+	if err := binary.Write(&b, binary.LittleEndian, reply.Timestamp); err != nil {
+		return err
+	}
+	cbuf := append(b.Bytes(), reply.MerkleRoot...)
+	c.Message(nil, nil, cbuf)
+	challenge := suite.Secret().Pick(c)
+	if challenge.Equal(reply.SigBroad.C) {
+		return nil
+	}
+	return errors.New("Challenge reconstructed is not equal to the one given ><")
+}
+
+// A simple verification of a schnorr signature given the message
+//TAKEN FROM SIG_TEST from abstract
+func SchnorrVerify(suite abstract.Suite, message []byte, publicKey abstract.Point, sig defs.BasicSignature) error {
+	r := sig.Resp
+	c := sig.Chall
+
+	// Check that: base**r_hat * X_hat**c == V_hat
+	// Equivalent to base**(r+xc) == base**(v) == T in vanillaElGamal
+	Aux := suite.Point()
+	V_clean := suite.Point()
+	V_clean.Add(V_clean.Mul(nil, r), Aux.Mul(publicKey, c))
+	// T is the recreated V_hat
+	T := suite.Point().Null()
+	T.Add(T, V_clean)
+
+	// Verify that the hash based on the message and T
+	// matches the challange c from the signature
+	// copy of hashSchnorr
+	bufPoint, _ := T.MarshalBinary()
+	cipher := suite.Cipher(bufPoint)
+	cipher.Message(nil, nil, message)
+	hash := suite.Secret().Pick(cipher)
+	if !hash.Equal(sig.Chall) {
+		return errors.New("invalid signature")
+	}
+	return nil
+}
+
+// Decodes the JSON coming from the CT-server and puts back in a 'StampReply'-structure
+func JSONtoSignature(sigStr string) (*defs.StampReply, error) {
+	tsm := &defs.TimeStampMessage{}
+	err := json.Unmarshal([]byte(sigStr), &tsm)
+	if err != nil {
+		dbg.Lvl2("Couldn't unmarshal ", sigStr)
+		return nil, err
+	}
+
+	return tsm.Srep, err
+}
+
+// Takes a file to be hashed - reads in chunks of 1MB
+func hashFile(name string) []byte {
+	hash := suite.Hash()
+	file, err := os.Open(name)
+	if err != nil {
+		dbg.Fatal("Couldn't open file", name)
+	}
+
+	buflen := 1024 * 1024
+	buf := make([]byte, buflen)
+	read := buflen
+	for read == buflen {
+		read, err = file.Read(buf)
+		if err != nil && err != io.EOF {
+			dbg.Fatal("Error while reading bytes")
+		}
+		hash.Write(buf)
+	}
+	return hash.Sum(nil)
+}

--- a/go/cosi/cosi.go
+++ b/go/cosi/cosi.go
@@ -18,10 +18,6 @@ import (
 var logUri = flag.String("log_uri", "http://localhost:8888", "CT log base URI")
 var dump = flag.Bool("dump", false, "Dump request to uri")
 
-func init() {
-	flag.IntVar(&dbg.DebugVisible, "debug", dbg.DebugVisible, "0 is silence and 5 is spam")
-}
-
 // Our crypto-suite used in the program
 var suite abstract.Suite
 
@@ -57,7 +53,13 @@ func main() {
 		}
 		dbg.Lvlf2("Reply is %+v", reply)
 		dbg.Lvlf2("SHA256 of STH is %+v", STH.SHA256RootHash)
-		conode.VerifySignature(suite, reply, public, STH.SHA256RootHash[:])
+		if conode.VerifySignature(suite, reply, public, STH.SHA256RootHash[:]){
+			dbg.Lvl1("Successfully received STH with hash", STH.SHA256RootHash[:])
+			dbg.Lvl1("and checked conode-signature to be OK")
+		} else {
+			dbg.Lvl1("STH with hash", STH.SHA256RootHash, "didn't verify conode-signature.")
+			dbg.Lvl1("Perhaps wrong config.toml?")
+		}
 	}
 }
 

--- a/go/cosi/cosi.go
+++ b/go/cosi/cosi.go
@@ -51,8 +51,8 @@ func main() {
 		if err != nil{
 			dbg.Fatal("Couldn't convert CosiSignature", err)
 		}
-		dbg.Lvlf2("Reply is %+v", reply)
-		dbg.Lvlf2("SHA256 of STH is %+v", STH.SHA256RootHash)
+		dbg.Lvlf3("Reply is %+v", reply)
+		dbg.Lvlf3("SHA256 of STH is %+v", STH.SHA256RootHash)
 		if conode.VerifySignature(suite, reply, public, STH.SHA256RootHash[:]){
 			dbg.Lvl1("Successfully received STH with hash", STH.SHA256RootHash[:])
 			dbg.Lvl1("and checked conode-signature to be OK")

--- a/go/cosi/cosi.go
+++ b/go/cosi/cosi.go
@@ -19,13 +19,22 @@ import (
 	"github.com/dedis/cothority/lib/proof"
 	"github.com/dedis/crypto/abstract"
 	"github.com/google/certificate-transparency/go/client"
+	"github.com/dedis/cothority/lib/conode"
 )
 
 // The base url is http://ct.googleapis.com/aviator
 var logUri = flag.String("log_uri", "http://localhost:8888", "CT log base URI")
 var dump = flag.Bool("dump", false, "Dump request to uri")
 
+// Our crypto-suite used in the program
+var suite abstract.Suite
+
+// The aggregate public key X0
 var public abstract.Point
+
+// the configuration file of the cothority tree used
+var conf *app.ConfigConode
+
 
 func main() {
 	flag.Parse()
@@ -46,10 +55,23 @@ func main() {
 	} else {
 		ReadConf()
 
-		sig, err := JSONtoSignature(STH.CosiSignature)
-		dbg.Printf("signature is %+v - error: %s\n", sig, err)
-		//verifySignature()
+		reply, err := JSONtoSignature(STH.CosiSignature)
+		dbg.Printf("Reply is %+v - error: %s", reply, err)
+		dbg.Printf("SHA256 of STH is %+v", STH.SHA256RootHash)
+		conode.VerifySignature(suite, reply, public, STH.SHA256RootHash)
 	}
+}
+
+// Decodes the JSON coming from the CT-server and puts back in a 'StampReply'-structure
+func JSONtoSignature(sigStr string) (*conode.StampReply, error) {
+	tsm := &conode.TimeStampMessage{}
+	err := json.Unmarshal([]byte(sigStr), &tsm)
+	if err != nil {
+		dbg.Lvl2("Couldn't unmarshal ", sigStr)
+		return nil, err
+	}
+
+	return tsm.Srep, err
 }
 
 func SetSuite(suiteStr string) {
@@ -64,135 +86,4 @@ func ReadConf() {
 	}
 	SetSuite(conf.Suite)
 	public, _ = cliutils.ReadPub64(suite, strings.NewReader(conf.AggPubKey))
-}
-
-// Our crypto-suite used in the program
-var suite abstract.Suite
-
-// the configuration file of the cothority tree used
-var conf *app.ConfigConode
-
-// Verifies that the 'message' is included in the signature and that it
-// is correct.
-// Message is your own hash, and reply contains the inclusion proof + signature
-// on the aggregated message
-func verifySignature(message hashid.HashId, reply *defs.StampReply) bool {
-	// First check if the challenge is ok
-	if err := verifyChallenge(suite, reply); err != nil {
-		dbg.Lvl1("Challenge-check : FAILED (", err, ")")
-		return false
-	}
-	dbg.Lvl1("Challenge-check : OK")
-	// Then check if the signature is ok
-	sig := defs.BasicSignature{
-		Chall: reply.SigBroad.C,
-		Resp:  reply.SigBroad.R0_hat,
-	}
-	public, _ := cliutils.ReadPub64(suite, strings.NewReader(conf.AggPubKey))
-	// Incorporate the timestamp in the message since the verification process
-	// is done by reconstructing the challenge
-	var b bytes.Buffer
-	if err := binary.Write(&b, binary.LittleEndian, reply.Timestamp); err != nil {
-		dbg.Lvl1("Error marshaling the timestamp for signature verification")
-	}
-	msg := append(b.Bytes(), []byte(reply.MerkleRoot)...)
-	if err := SchnorrVerify(suite, msg, public, sig); err != nil {
-		dbg.Lvl1("Signature-check : FAILED (", err, ")")
-		return false
-	}
-	dbg.Lvl1("Signature-check : OK")
-
-	// finally check the proof
-	if !proof.CheckProof(suite.Hash, reply.MerkleRoot, hashid.HashId(message), reply.Prf) {
-		dbg.Lvl1("Inclusion-check : FAILED")
-		return false
-	}
-	dbg.Lvl1("Inclusion-check : OK")
-	return true
-}
-
-// verifyChallenge will recontstruct the challenge in order to see if any of the
-// components of the challenge has been spoofed or not. It may be a different
-// timestamp .
-func verifyChallenge(suite abstract.Suite, reply *defs.StampReply) error {
-
-	// marshal the V
-	pbuf, err := reply.SigBroad.V0_hat.MarshalBinary()
-	if err != nil {
-		return err
-	}
-	c := suite.Cipher(pbuf)
-	// concat timestamp and merkle root
-	var b bytes.Buffer
-	if err := binary.Write(&b, binary.LittleEndian, reply.Timestamp); err != nil {
-		return err
-	}
-	cbuf := append(b.Bytes(), reply.MerkleRoot...)
-	c.Message(nil, nil, cbuf)
-	challenge := suite.Secret().Pick(c)
-	if challenge.Equal(reply.SigBroad.C) {
-		return nil
-	}
-	return errors.New("Challenge reconstructed is not equal to the one given ><")
-}
-
-// A simple verification of a schnorr signature given the message
-//TAKEN FROM SIG_TEST from abstract
-func SchnorrVerify(suite abstract.Suite, message []byte, publicKey abstract.Point, sig defs.BasicSignature) error {
-	r := sig.Resp
-	c := sig.Chall
-
-	// Check that: base**r_hat * X_hat**c == V_hat
-	// Equivalent to base**(r+xc) == base**(v) == T in vanillaElGamal
-	Aux := suite.Point()
-	V_clean := suite.Point()
-	V_clean.Add(V_clean.Mul(nil, r), Aux.Mul(publicKey, c))
-	// T is the recreated V_hat
-	T := suite.Point().Null()
-	T.Add(T, V_clean)
-
-	// Verify that the hash based on the message and T
-	// matches the challange c from the signature
-	// copy of hashSchnorr
-	bufPoint, _ := T.MarshalBinary()
-	cipher := suite.Cipher(bufPoint)
-	cipher.Message(nil, nil, message)
-	hash := suite.Secret().Pick(cipher)
-	if !hash.Equal(sig.Chall) {
-		return errors.New("invalid signature")
-	}
-	return nil
-}
-
-// Decodes the JSON coming from the CT-server and puts back in a 'StampReply'-structure
-func JSONtoSignature(sigStr string) (*defs.StampReply, error) {
-	tsm := &defs.TimeStampMessage{}
-	err := json.Unmarshal([]byte(sigStr), &tsm)
-	if err != nil {
-		dbg.Lvl2("Couldn't unmarshal ", sigStr)
-		return nil, err
-	}
-
-	return tsm.Srep, err
-}
-
-// Takes a file to be hashed - reads in chunks of 1MB
-func hashFile(name string) []byte {
-	hash := suite.Hash()
-	file, err := os.Open(name)
-	if err != nil {
-		dbg.Fatal("Couldn't open file", name)
-	}
-
-	buflen := 1024 * 1024
-	buf := make([]byte, buflen)
-	read := buflen
-	for read == buflen {
-		read, err = file.Read(buf)
-		if err != nil && err != io.EOF {
-			dbg.Fatal("Error while reading bytes")
-		}
-		hash.Write(buf)
-	}
-	return hash.Sum(nil)
 }

--- a/go/cosi/cosi.go
+++ b/go/cosi/cosi.go
@@ -1,22 +1,14 @@
 package main
 
 import (
-	"bytes"
-	"encoding/binary"
 	"encoding/json"
-	"errors"
 	"flag"
-	"io"
 	"io/ioutil"
-	"os"
 	"strings"
 
-	"github.com/dedis/cothority/app/conode/defs"
 	"github.com/dedis/cothority/lib/app"
 	"github.com/dedis/cothority/lib/cliutils"
 	dbg "github.com/dedis/cothority/lib/debug_lvl"
-	"github.com/dedis/cothority/lib/hashid"
-	"github.com/dedis/cothority/lib/proof"
 	"github.com/dedis/crypto/abstract"
 	"github.com/google/certificate-transparency/go/client"
 	"github.com/dedis/cothority/lib/conode"
@@ -54,11 +46,12 @@ func main() {
 			[]byte(STH.SHA256RootHash.Base64String()), 0660)
 	} else {
 		ReadConf()
+    dbg.DebugVisible = 3
 
 		reply, err := JSONtoSignature(STH.CosiSignature)
 		dbg.Printf("Reply is %+v - error: %s", reply, err)
 		dbg.Printf("SHA256 of STH is %+v", STH.SHA256RootHash)
-		conode.VerifySignature(suite, reply, public, STH.SHA256RootHash)
+		conode.VerifySignature(suite, reply, public, STH.SHA256RootHash[:])
 	}
 }
 

--- a/go/cosi/cosi_test.go
+++ b/go/cosi/cosi_test.go
@@ -6,6 +6,7 @@ import (
 	dbg "github.com/dedis/cothority/lib/debug_lvl"
 	"io/ioutil"
 	"testing"
+	"github.com/dedis/cothority/lib/conode"
 )
 
 func TestReadConf(t *testing.T) {
@@ -61,55 +62,9 @@ func TestVerify(t *testing.T) {
 	}
 	dbg.Print("HashByte:", sthHashByte)
 
-	if verifySignature(sthHashByte, reply) {
+	if conode.VerifySignature(suite, reply, public, sthHashByte) {
 		dbg.Print("Yay - passing all tests")
 	} else {
 		dbg.Fatal("Oups - some more work to do")
 	}
 }
-
-/*
-func TestVerify(t *testing.T) {
-	ReadConf()
-	str, _ := ioutil.ReadFile("test_sth_cosi.json")
-	reply, err := JSONtoSignature(string(str))
-	if err != nil {
-		dbg.Fatal("Couldn't read json from ", str)
-	}
-
-	err = verifyChallenge(suite, reply)
-	if err != nil {
-		dbg.Fatal("Couldn't check the challenge")
-	} else {
-		dbg.Lvl1("Challenge is OK")
-	}
-
-	sig := defs.BasicSignature{
-		Chall: reply.SigBroad.C,
-		Resp:  reply.SigBroad.R0_hat,
-	}
-
-	sthHash, err := ioutil.ReadFile("test_sth_sha256.json")
-	if err != nil {
-		dbg.Fatal("Couldn't read sha256-hash")
-	}
-	sthHashByte, err := base64.StdEncoding.DecodeString(string(sthHash))
-	if err != nil {
-		dbg.Fatal("Couldn't convert", sthHash, "from base64")
-	}
-	dbg.Print("HashByte:", sthHashByte)
-	//sthHashHex := hex.EncodeToString(sthHashByte);
-
-	var b bytes.Buffer
-	if err := binary.Write(&b, binary.LittleEndian, reply.Timestamp); err != nil {
-		dbg.Lvl1("Error marshaling the timestamp for signature verification")
-	}
-	msg := append(b.Bytes(), []byte(reply.MerkleRoot)...)
-	err = SchnorrVerify(suite, []byte(sthHashByte), public, sig)
-	//err = SchnorrVerify(suite, []byte("test"), public, sig)
-	if err != nil {
-		dbg.Fatal("Couldn't verify Schnorr")
-	}
-	return
-}
-*/

--- a/go/cosi/cosi_test.go
+++ b/go/cosi/cosi_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"github.com/dedis/cothority/app/conode/defs"
+	dbg "github.com/dedis/cothority/lib/debug_lvl"
+	"io/ioutil"
+	"testing"
+)
+
+func TestReadConf(t *testing.T) {
+	ReadConf()
+
+	dbg.Printf("%+v\n", conf)
+	dbg.Printf("Public key: %+v", public)
+}
+
+func TestReadSha(t *testing.T){
+	sthHash, _ := ioutil.ReadFile("test_sth_sha256.json")
+  dbg.Print("Hash:", sthHash)
+	sthHashByte, err := base64.StdEncoding.DecodeString(string(sthHash))
+	if err != nil {
+		dbg.Fatal("Couldn't convert", sthHash, "from base64")
+	}
+	dbg.Print("HashByte:", sthHashByte)
+  sthHashHex := hex.EncodeToString(sthHashByte);
+	dbg.Print("HashHex:", sthHashHex)
+}
+
+func TestJSONtoSignature(t *testing.T) {
+	str, err := ioutil.ReadFile("test_sth_cosi.json")
+	dbg.DebugVisible = 5
+	SetSuite("ed25519")
+
+	reply, err := JSONtoSignature(string(str))
+	dbg.Printf("Reply is: %+v - %s\n", reply, err)
+
+	ReadConf()
+	if reply.SigBroad.X0_hat.Equal(public) {
+		dbg.Lvl2("X0 verified")
+	}
+}
+
+func TestVerify(t *testing.T) {
+	ReadConf()
+	str, _ := ioutil.ReadFile("test_sth_cosi.json")
+	reply, err := JSONtoSignature(string(str))
+	if err != nil {
+		dbg.Fatal("Couldn't read json from ", str)
+	}
+
+	err = verifyChallenge(suite, reply)
+	if err != nil {
+		dbg.Fatal("Couldn't check the challenge")
+	}
+
+	sig := defs.BasicSignature{
+		Chall: reply.SigBroad.C,
+		Resp:  reply.SigBroad.R0_hat,
+	}
+
+	sthHash, err := ioutil.ReadFile("test_sth_sha256.json")
+	if err != nil {
+		dbg.Fatal("Couldn't read sha256-hash")
+	}
+	sthHashByte, err := base64.StdEncoding.DecodeString(string(sthHash))
+	if err != nil {
+		dbg.Fatal("Couldn't convert", sthHash, "from base64")
+	}
+  staHashHex := hex.EncodeToString(sthHashByte);
+	err = SchnorrVerify(suite, []byte(staHashHex), public, sig)
+	err = SchnorrVerify(suite, []byte("test"), public, sig)
+	if err != nil {
+		dbg.Fatal("Couldn't verify Schnorr")
+	}
+	return
+}

--- a/go/scanner/scanner.go
+++ b/go/scanner/scanner.go
@@ -382,6 +382,7 @@ func (s *Scanner) Scan(foundCert func(*ct.LogEntry),
 	s.Log(fmt.Sprintf("Completed %d certs in %s", s.certsProcessed, humanTime(int(time.Since(startTime).Seconds()))))
 	s.Log(fmt.Sprintf("Saw %d precerts", s.precertsSeen))
 	s.Log(fmt.Sprintf("%d unparsable entries, %d non-fatal errors", s.unparsableEntries, s.entriesWithNonFatalErrors))
+	s.Log(fmt.Sprintf("STH is: %+v\n", latestSth))
 	return nil
 }
 

--- a/go/scanner/scanner.go
+++ b/go/scanner/scanner.go
@@ -382,7 +382,7 @@ func (s *Scanner) Scan(foundCert func(*ct.LogEntry),
 	s.Log(fmt.Sprintf("Completed %d certs in %s", s.certsProcessed, humanTime(int(time.Since(startTime).Seconds()))))
 	s.Log(fmt.Sprintf("Saw %d precerts", s.precertsSeen))
 	s.Log(fmt.Sprintf("%d unparsable entries, %d non-fatal errors", s.unparsableEntries, s.entriesWithNonFatalErrors))
-	s.Log(fmt.Sprintf("STH is: %+v\n", latestSth))
+	s.Log(fmt.Sprintf("Latest STH: %+v\n", latestSth ) )
 	return nil
 }
 

--- a/go/types.go
+++ b/go/types.go
@@ -285,6 +285,7 @@ type SignedTreeHead struct {
 	SHA256RootHash    SHA256Hash      `json:"sha256_root_hash"`    // The root hash of the log's Merkle tree
 	TreeHeadSignature DigitallySigned `json:"tree_head_signature"` // The Log's signature for this STH (see RFC section 3.5)
 	LogID             SHA256Hash      `json:"log_id"`              // The SHA256 hash of the log's public key
+	CosiSignature			string					`json:"cosi_signature"`		 // The additional cothority-signature
 }
 
 // SignedCertificateTimestamp represents the structure returned by the

--- a/pre_install.macos
+++ b/pre_install.macos
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+PACKAGES="gflags glog protobuf json-c automake pkg-config libevent leveldb"
+
+if [ ! "$( which brew )" ]; then
+  echo Please install 'brew' first!
+  echo 'ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"'
+  echo
+  exit 1
+fi
+
+for p in $PACKAGES; do
+  brew install $p
+done

--- a/proto/ct.proto
+++ b/proto/ct.proto
@@ -187,6 +187,7 @@ message SignedTreeHead {
   optional int64 tree_size = 4;
   optional bytes sha256_root_hash = 5;
   optional DigitallySigned signature = 6;
+  optional bytes cosi_signature = 7;
 }
 
 // Stuff the SSL client spits out from a connection.


### PR DESCRIPTION
This adds an UNSUPPORTED cosi_signature-field to the SignedTreeHead. For each new STH it contacts a cosi-node (for the moment the only one running at 78.46.227.60:2001), submits the hash of the STH and puts the received signature (JSON-field with the entries required to check a signature) in the cosi_signature-field.

There is a simple stamp_request_test-file that checks the possibility to receive a signature from the cosi-server.
